### PR TITLE
[TASK] Adds the ability to automatically display the page title

### DIFF
--- a/Configuration/TCA/Overrides/100_pages.php
+++ b/Configuration/TCA/Overrides/100_pages.php
@@ -88,11 +88,20 @@ $additionalColumns = [
             'renderType' => 'checkboxToggle',
         ],
     ],
+    'automatic_title' => [
+        'exclude' => true,
+        'label' => 'LLL:EXT:bulma_package/Resources/Private/Language/Backend.xlf:pages.automatic_title',
+        'description' => 'LLL:EXT:bulma_package/Resources/Private/Language/Backend.xlf:pages.automatic_title.description',
+        'config' => [
+            'type' => 'check',
+            'renderType' => 'checkboxToggle',
+        ],
+    ],
 ];
 
 ExtensionManagementUtility::addTCAcolumns('pages', $additionalColumns);
 ExtensionManagementUtility::addToAllTCAtypes('pages', 'thumbnail', '1,3,4', 'after:backend_layout_next_level');
-ExtensionManagementUtility::addToAllTCAtypes('pages', 'hide_breadcrumb', (string)PageRepository::DOKTYPE_DEFAULT, 'after:thumbnail');
+ExtensionManagementUtility::addToAllTCAtypes('pages', 'hide_breadcrumb, automatic_title', (string)PageRepository::DOKTYPE_DEFAULT, 'after:thumbnail');
 ExtensionManagementUtility::addFieldsToPalette('pages', 'title', 'exclude_slug_for_subpages', 'after:slug');
 ExtensionManagementUtility::addFieldsToPalette('pages', 'titleonly', 'exclude_slug_for_subpages', 'after:slug');
 

--- a/Configuration/TsConfig/Page/TCEFORM.tsconfig
+++ b/Configuration/TsConfig/Page/TCEFORM.tsconfig
@@ -371,3 +371,13 @@ TCEFORM {
     }
   }
 }
+
+# Disable automatic_title by default
+TCEFORM.pages.automatic_title.disabled = 1
+
+# Enable automatic_title field, and change default to 1
+# when automaticPageTitle is set to 1
+[traverse(site("configuration"), "settings/automaticPageTitle") == 1]
+  TCEFORM.pages.automatic_title.disabled = 0
+  TCAdefaults.pages.automatic_title = 1
+[END]

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -222,6 +222,10 @@ page {
   }
 }
 
+[traverse(site("configuration"), "settings/automaticPageTitle") == 1]
+  page.10.settings.automaticTitle = 1
+[END]
+
 ####################
 #### COMPONENTS ####
 ####################

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -849,6 +849,12 @@
 			<trans-unit id="content_element.site_update.description">
 				<source>Displays the date the site was last updated, based on updates to content or pages.</source>
 			</trans-unit>
+			<trans-unit id="pages.automatic_title">
+				<source>Automatic title</source>
+			</trans-unit>
+			<trans-unit id="pages.automatic_title.description">
+				<source>Automatically displays the page title as a level 1 heading, at the top of the main content area.</source>
+			</trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Partials/Page/Structure/PageTitle.html
+++ b/Resources/Private/Partials/Page/Structure/PageTitle.html
@@ -1,0 +1,12 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<f:if condition="{settings.automaticTitle} && {data.automatic_title} && {breadcrumb}">
+    <header id="page-title" class="container frame">
+        <h1 class="title is-1">{data.title}</h1>
+        <f:if condition="{data.subtitle}">
+            <h2 class="subtitle is-2">{data.subtitle}</h2>
+        </f:if>
+    </header>
+</f:if>
+
+</html>

--- a/Resources/Private/Templates/Page/Default.html
+++ b/Resources/Private/Templates/Page/Default.html
@@ -5,6 +5,7 @@
     <f:render partial="Navigation/Breadcrumb" arguments="{_all}" />
 
     <main id="main" role="main">
+        <f:render partial="Structure/PageTitle" arguments="{_all}" />
         <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
     </main>
 

--- a/Resources/Private/Templates/Page/SidebarLeft.html
+++ b/Resources/Private/Templates/Page/SidebarLeft.html
@@ -14,6 +14,7 @@
                 <div class="container{f:if(condition: '{breadcrumb} && !{data.hide_breadcrumb}', then: ' after-breadcrumb')}">
                     <div class="{settings.layouts.{current}.columns.wrapperClasses}">
                         <main id="main" role="main" class="{settings.layouts.{current}.columns.mainClasses}">
+                            <f:render partial="Structure/PageTitle" arguments="{_all}" />
                             <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
                         </main>
                         <aside class="{settings.layouts.{current}.columns.asideClasses}">
@@ -25,6 +26,7 @@
         </f:then>
         <f:else>
             <main id="main" role="main">
+                <f:render partial="Structure/PageTitle" arguments="{_all}" />
                 <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
             </main>
         </f:else>

--- a/Resources/Private/Templates/Page/SidebarLeftWNavigation.html
+++ b/Resources/Private/Templates/Page/SidebarLeftWNavigation.html
@@ -12,6 +12,7 @@
         <div class="container{f:if(condition: '{breadcrumb} && !{data.hide_breadcrumb}', then: ' after-breadcrumb')}">
             <div class="{settings.layouts.{current}.columns.wrapperClasses}">
                 <main id="main" role="main" class="{settings.layouts.{current}.columns.mainClasses}">
+                    <f:render partial="Structure/PageTitle" arguments="{_all}" />
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
                 </main>
                 <aside class="{settings.layouts.{current}.columns.asideClasses}">

--- a/Resources/Private/Templates/Page/SidebarRight.html
+++ b/Resources/Private/Templates/Page/SidebarRight.html
@@ -14,6 +14,7 @@
                 <div class="container{f:if(condition: '{breadcrumb} && !{data.hide_breadcrumb}', then: ' after-breadcrumb')}">
                     <div class="{settings.layouts.{current}.columns.wrapperClasses}">
                         <main id="main" role="main" class="{settings.layouts.{current}.columns.mainClasses}">
+                            <f:render partial="Structure/PageTitle" arguments="{_all}" />
                             <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
                         </main>
                         <aside class="{settings.layouts.{current}.columns.asideClasses}">
@@ -25,6 +26,7 @@
         </f:then>
         <f:else>
             <main id="main" role="main">
+                <f:render partial="Structure/PageTitle" arguments="{_all}" />
                 <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
             </main>
         </f:else>

--- a/Resources/Private/Templates/Page/SidebarRightWNavigation.html
+++ b/Resources/Private/Templates/Page/SidebarRightWNavigation.html
@@ -12,6 +12,7 @@
         <div class="container{f:if(condition: '{breadcrumb} && !{data.hide_breadcrumb}', then: ' after-breadcrumb')}">
             <div class="{settings.layouts.{current}.columns.wrapperClasses}">
                 <main id="main" role="main" class="{settings.layouts.{current}.columns.mainClasses}">
+                    <f:render partial="Structure/PageTitle" arguments="{_all}" />
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
                 </main>
                 <aside class="{settings.layouts.{current}.columns.asideClasses}">

--- a/Resources/Public/Scss/Theme/_frame.scss
+++ b/Resources/Public/Scss/Theme/_frame.scss
@@ -19,7 +19,7 @@ $frame-spacing-negative-xl: $frame-spacing-xl !default;
     padding: $frame-spacing 0;
   }
 
-  &:first-of-type {
+  &:not(.frame ~ .frame) {
     &:not([class*="frame-space-before-"]):not([class*="has-background-"]):not(.is-background-limited) {
       padding-top: 0;
       margin-top: $frame-spacing;


### PR DESCRIPTION
To enable this feature, add `automaticPageTitle: 1` to the site settings (https://docs.typo3.org/permalink/t3coreapi:sitehandling-settings-add).

Once enabled globally, the feature can be disabled in the page properties.

On an existing site, the feature will only be active for new pages.